### PR TITLE
Add Item namespaces and Offer namespaces pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ``` bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # serve with hot reload at localhost:3000
 $ npm run dev

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -8,7 +8,9 @@
       <b-collapse id="nav-collapse" is-nav>
         <b-navbar-nav>
           <b-nav-item href="/items">Items</b-nav-item>
+          <b-nav-item href="/item_namespaces">Item Namespaces</b-nav-item>
           <b-nav-item href="/offers">Offers</b-nav-item>
+          <b-nav-item href="/offer_namespaces">Offer Namespaces</b-nav-item>
           <b-nav-item href="/offers?category=games&sortBy=5">New Games</b-nav-item>
           <b-nav-item to="/promotions">Promotions</b-nav-item>
           <b-nav-item href="https://github.com/EpicData-info" target="_blank">Github</b-nav-item>

--- a/components/Namespaces.vue
+++ b/components/Namespaces.vue
@@ -56,7 +56,7 @@
       }
     },
     async mounted() {
-      const {data} = await this.$axios.get(`https://api.allorigins.win/raw?url=https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/namespaces.json`);
+      const {data} = await this.$axios.get(`https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/namespaces.json`);
       this.namespaceJSON = data;
       this.show = false;
 

--- a/components/Namespaces.vue
+++ b/components/Namespaces.vue
@@ -1,0 +1,81 @@
+<template>
+  <main>
+    <b-overlay :show="show" rounded="sm">
+      <!-- Search -->
+      <div class="search-wrapper">
+        <b-form-input v-model="searchFilter" placeholder="🔍 Search namespace"></b-form-input>
+      </div>
+
+      <!-- Main content -->
+      <div class="namespace-list" role="tablist">
+        <b-card no-body class="mb-1" v-for="namespace in namespaces">
+          <b-card-header header-tag="header" class="p-1" role="tab">
+            <b-button block v-b-toggle="'accordion-'+namespace" variant="info">
+              {{namespace}}
+            </b-button>
+          </b-card-header>
+          <b-collapse :id="'accordion-'+ namespace" accordion="my-accordion" role="tabpanel">
+            <b-card-body class="id-list">
+              <b-link :href="getLinkFor(id)" v-for="id in getIDsFrom(namespace)">
+                {{id}}
+              </b-link>
+            </b-card-body>
+          </b-collapse>
+        </b-card>
+      </div>
+    </b-overlay>
+  </main>
+</template>
+
+<script>
+  export default {
+    props: ['type'],
+    data() {
+      return {
+        show: true,
+        searchFilter: "",
+        namespaceJSON: {}
+      }
+    },
+    computed: {
+      namespaces() {
+        return Object.keys(this.namespaceJSON).filter( namespace => {
+          if(this.searchFilter)
+            return namespace.toLowerCase().includes(this.searchFilter.toLowerCase())
+          else
+            return true
+        })
+      }
+    },
+    methods: {
+      getIDsFrom(namespace) {
+        return this.namespaceJSON[namespace]
+      },
+      getLinkFor(id) {
+        return `https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/${this.type}s/${id}.json`
+      }
+    },
+    async mounted() {
+      const {data} = await this.$axios.get(`https://api.allorigins.win/raw?url=https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/namespaces.json`);
+      this.namespaceJSON = data;
+      this.show = false;
+
+    },
+  }
+</script>
+
+<style scoped>
+  .search-wrapper {
+    width: 512px;
+    margin: 16px auto;
+  }
+
+  .namespace-list {
+    width: 512px;
+    margin: 16px auto;
+  }
+
+  .id-list{
+    text-align: center;
+  }
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,9 @@
   <main class="container">
     <b-jumbotron header="EpicData.info" lead="EpicGames Store data tracker." style="margin:2rem 0">
       <b-button variant="primary" to="/items">Items</b-button>
+      <b-button variant="primary" to="/item_namespaces">Item Namespaces</b-button>
       <b-button variant="primary" to="/offers">Offers</b-button>
+      <b-button variant="primary" to="/offer_namespaces">Offer Namespaces</b-button>
       <b-button variant="primary" to="/offers?category=games&sortBy=5">New Games</b-button>
       <b-button variant="primary" to="/promotions">Promotions</b-button>
       <b-button variant="success" :href="this.$store.state.donateUrl" target="_blank">Donate</b-button>

--- a/pages/item_namespaces.vue
+++ b/pages/item_namespaces.vue
@@ -1,0 +1,14 @@
+<template>
+  <namespaces type="item"/>
+</template>
+
+<script>
+  import Namespaces from "@/components/namespaces"
+
+  export default {
+    components: {
+      'namespaces': Namespaces
+    },
+  }
+
+</script>

--- a/pages/offer_namespaces.vue
+++ b/pages/offer_namespaces.vue
@@ -1,0 +1,14 @@
+<template>
+  <namespaces type="offer"/>
+</template>
+
+<script>
+  import Namespaces from "@/components/namespaces"
+
+  export default {
+    components: {
+      'namespaces': Namespaces
+    },
+  }
+
+</script>


### PR DESCRIPTION
Good day.
Great job on the database, but the front-end is lacking a feature that I would really like to see implemented. I am talking about displaying all namespaces with their items/offers in one view with a search bar. I have implemented a quick prototype based on this idea, so try running my fork of the frontend locally to see what exactly I mean. You can probably improve it and integrate better with your frontend. I really find the ability to directly view the list of namespaces with their items/offers as hyperlinks really useful.