### PR TITLE
Added json viewer to the item/offer details

### DIFF
--- a/components/Namespaces.vue
+++ b/components/Namespaces.vue
@@ -8,16 +8,18 @@
 
       <!-- Main content -->
       <div class="namespace-list" role="tablist">
-        <b-card no-body class="mb-1" v-for="namespace in namespaces" :key="namespace">
+        <b-card no-body class="mb-1" :key="namespace"
+                v-for="namespace in namespaces"
+                v-show="getVisibility(namespace)">
           <b-card-header header-tag="header" class="p-1" role="tab">
             <b-button block v-b-toggle="'accordion-'+namespace" variant="info">
-              {{namespace}}
+              {{ namespace }}
             </b-button>
           </b-card-header>
           <b-collapse :id="'accordion-'+ namespace" accordion="my-accordion" role="tabpanel">
             <b-card-body class="id-list">
               <b-link :href="getLinkFor(id)" target="_blank" v-for="id in getIDsFrom(namespace)" :key="id">
-                {{id}}
+                {{ id }}
               </b-link>
             </b-card-body>
           </b-collapse>
@@ -28,54 +30,53 @@
 </template>
 
 <script>
-  export default {
-    props: ['type'],
-    data() {
-      return {
-        show: true,
-        searchFilter: "",
-        namespaceJSON: {}
-      }
-    },
-    computed: {
-      namespaces() {
-        return Object.keys(this.namespaceJSON).filter( namespace => {
-          if(this.searchFilter)
-            return namespace.toLowerCase().includes(this.searchFilter.toLowerCase())
-          else
-            return true
-        })
-      }
-    },
-    methods: {
-      getIDsFrom(namespace) {
-        return this.namespaceJSON[namespace]
-      },
-      getLinkFor(id) {
-        return `https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/${this.type}s/${id}.json`
-      }
-    },
-    async mounted() {
-      const {data} = await this.$axios.get(`https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/namespaces.json`);
-      this.namespaceJSON = data;
-      this.show = false;
 
+export default {
+  props: ['type'],
+  data() {
+    return {
+      show: true,
+      searchFilter: "",
+      namespaceJSON: {}
+    }
+  },
+  computed: {
+    namespaces() {
+      return Object.keys(this.namespaceJSON)
+    }
+  },
+  methods: {
+    getIDsFrom(namespace) {
+      return this.namespaceJSON[namespace]
     },
-  }
+    getLinkFor(id) {
+      return `https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/${this.type}s/${id}.json`
+    },
+    getVisibility(namespace) {
+      return !this.searchFilter || namespace.toLowerCase().includes(this.searchFilter.toLowerCase())
+    }
+  },
+  async mounted() {
+    const {data} = await this.$axios.get(`https://raw.githubusercontent.com/EpicData-info/${this.type}s-tracker/master/database/namespaces.json`);
+    this.namespaceJSON = data;
+    this.show = false;
+
+  },
+}
 </script>
 
 <style scoped>
-  .search-wrapper {
-    width: 512px;
-    margin: 16px auto;
-  }
+.search-wrapper {
+  width: 512px;
+  margin: 16px auto;
+}
 
-  .namespace-list {
-    width: 512px;
-    margin: 16px auto;
-  }
+.namespace-list {
+  width: 512px;
+  margin: 16px auto;
+}
 
-  .id-list{
-    text-align: center;
-  }
+.id-list {
+  text-align: center;
+}
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9480,6 +9480,11 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
+    "vue-json-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/vue-json-component/-/vue-json-component-0.4.1.tgz",
+      "integrity": "sha512-8Tw4C5LJOT09BRKjQx8F5itheP7UIeZtUUJvWnSltb0UFQZSrXw/4B32z3pelWo38MtoglaSmFTYpyxFIWWNRg=="
+    },
     "vue-loader": {
       "version": "15.9.3",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "chart.js": "^2.9.3",
     "moment": "^2.27.0",
     "nuxt": "^2.0.0",
-    "vue-chartjs": "^3.5.0"
+    "vue-chartjs": "^3.5.0",
+    "vue-json-component": "^0.4.1"
   },
   "devDependencies": {
     "push-dir": "^0.4.1"

--- a/pages/item/_id.vue
+++ b/pages/item/_id.vue
@@ -6,14 +6,9 @@
     <b-container fluid>
       <b-row>
         <b-col sm="12">
-          <b-form-textarea
-            id="textarea-auto-height"
-            placeholder="Auto height textarea"
-            rows="3"
-            max-rows="100"
-            readonly
-            v-model="stringifiedDetails"
-          ></b-form-textarea>
+          <json-view
+            :data="details"
+            class="chevronStyle"/>
         </b-col>
       </b-row>
     </b-container>
@@ -40,21 +35,26 @@
 </template>
 
 <script>
+
+import {JSONView} from 'vue-json-component';
+
 export default {
-  data () {
+  components: {'json-view': JSONView},
+  data() {
     return {
       slide: 0,
       details: {},
     };
   },
-  computed: {
-    stringifiedDetails () {
-      return JSON.stringify(this.details, null, 2);
-    },
-  },
-  async mounted () {
-    const { data: details } = await this.$axios.get(`https://raw.githubusercontent.com/EpicData-info/items-tracker/master/database/items/${this.$route.params.id}.json`);
+  async mounted() {
+    const {data: details} = await this.$axios.get(`https://raw.githubusercontent.com/EpicData-info/items-tracker/master/database/items/${this.$route.params.id}.json`);
     this.details = details;
   },
 }
 </script>
+
+<style scoped>
+.chevronStyle {
+  --vjc-arrow-size: 10px !important;
+}
+</style>

--- a/pages/offer/_id.vue
+++ b/pages/offer/_id.vue
@@ -6,14 +6,9 @@
     <b-container fluid>
       <b-row>
         <b-col sm="12">
-          <b-form-textarea
-            id="textarea-auto-height"
-            placeholder="Auto height textarea"
-            rows="3"
-            max-rows="100"
-            readonly
-            v-model="stringifiedDetails"
-          ></b-form-textarea>
+          <json-view
+            :data="details"
+            class="chevronStyle"/>
         </b-col>
       </b-row>
     </b-container>
@@ -48,9 +43,11 @@
 <script>
 import Moment from 'moment';
 import PriceChart from '@/components/PriceChart';
+import {JSONView} from 'vue-json-component';
 
 export default {
   components: {
+    'json-view': JSONView,
     PriceChart,
   },
   data () {
@@ -152,3 +149,8 @@ export default {
   },
 }
 </script>
+<style scoped>
+.chevronStyle {
+  --vjc-arrow-size: 10px !important;
+}
+</style>


### PR DESCRIPTION
Hello there.

I have added a json tree renderer from [this repo](https://github.com/tylerkrupicka/vue-json-component) to the details of the item/offer page. I think it makes it a bit more user friendly than the plain raw json. And if a user want the raw json, he can still access if from the item/offer namespace pages. What do you think about it?

<details>
<summary>Here is how it looks like</summary>

![image](https://user-images.githubusercontent.com/67734819/95984704-4857de00-0e2c-11eb-9db3-97eac69a5b17.png)
</details>
